### PR TITLE
Update sitemap defaults

### DIFF
--- a/src/Http/Controllers/SitemapController.php
+++ b/src/Http/Controllers/SitemapController.php
@@ -15,6 +15,7 @@ use Illuminate\Routing\Controller as BaseController;
 class SitemapController extends BaseController
 {
     protected Sitemap $sitemap;
+    protected $defaultFilename = 'sitemap.xml';
 
     /**
      * SitemapController constructor.
@@ -31,9 +32,9 @@ class SitemapController extends BaseController
      *
      * @throws FileNotFoundException
      */
-    public function __invoke(?string $filename): Response
+    public function __invoke(): Response
     {
-        $contents = $this->sitemap->getSitemapContents($filename);
+        $contents = $this->sitemap->getSitemapContents($this->defaultFilename);
 
         return response($contents, 200)
             ->header('Content-Type', 'application/xml');

--- a/src/Http/Controllers/SitemapController.php
+++ b/src/Http/Controllers/SitemapController.php
@@ -15,6 +15,7 @@ use Illuminate\Routing\Controller as BaseController;
 class SitemapController extends BaseController
 {
     protected Sitemap $sitemap;
+
     protected $defaultFilename = 'sitemap.xml';
 
     /**

--- a/src/SitemapServiceProvider.php
+++ b/src/SitemapServiceProvider.php
@@ -36,8 +36,7 @@ class SitemapServiceProvider extends PackageServiceProvider
      */
     public function PackageRegistered(): void
     {
-        Route::get('/{filename}', SitemapController::class)
-            ->where('filename', '.*\.xml$')
+        Route::get('/sitemap.xml', SitemapController::class)
             ->name('sitemap');
     }
 }


### PR DESCRIPTION
Updates the default behavior of the sitemap generation in the project. The changes include:

- Setting a default filename 'sitemap.xml' in the SitemapController.
- Modifying the SitemapController's __invoke method to use the default filename instead of accepting a filename parameter.
- Updating the route configuration in the SitemapServiceProvider to always use the 'sitemap.xml' endpoint for sitemap generation.

By making these changes, the sitemap generation process is streamlined and made more consistent by always using the default filename 'sitemap.xml'. This simplification enhances the clarity and maintainability of the codebase.