### PR TITLE
Refactored the GitHub workflow to run only if the actor is not Dependabot. Updated the return type of the  method in the  class to use the  constants for success and failure.

### DIFF
--- a/.github/workflows/open-ai-pr-description.yml
+++ b/.github/workflows/open-ai-pr-description.yml
@@ -15,7 +15,7 @@ jobs:
   openai-pr-description:
     runs-on: ubuntu-22.04
     # Run the job only if the actor is NOT Dependabot
-    if: ${{ !startsWith(github.actor, 'dependabot') }
+    if: ${{ !startsWith(github.actor, 'dependabot') }}
     steps:
       - uses: platisd/openai-pr-description@master
         with:

--- a/src/Commands/SitemapGenerateCommand.php
+++ b/src/Commands/SitemapGenerateCommand.php
@@ -61,10 +61,12 @@ class SitemapGenerateCommand extends Command
             }
 
             $this->info('Sitemap generated successfully.');
+
             return CommandAlias::SUCCESS;
         } catch (Exception $e) {
             Log::error('Sitemap generation failed: '.$e->getMessage());
             $this->error('Sitemap generation failed: '.$e->getMessage());
+
             return CommandAlias::FAILURE;
         }
     }

--- a/src/Commands/SitemapGenerateCommand.php
+++ b/src/Commands/SitemapGenerateCommand.php
@@ -15,6 +15,7 @@ use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\SitemapGenerator;
 use Spatie\Sitemap\SitemapIndex;
 use Spatie\Sitemap\Tags\Url;
+use Symfony\Component\Console\Command\Command as CommandAlias;
 
 class SitemapGenerateCommand extends Command
 {
@@ -33,7 +34,7 @@ class SitemapGenerateCommand extends Command
      * and posts and then either create a sitemap index to include them or
      * directly generate a single sitemap.
      */
-    public function handle(): bool
+    public function handle(): int
     {
         $this->diskName = $this->getDiskName();
 
@@ -60,13 +61,11 @@ class SitemapGenerateCommand extends Command
             }
 
             $this->info('Sitemap generated successfully.');
-
-            return true;
+            return CommandAlias::SUCCESS;
         } catch (Exception $e) {
             Log::error('Sitemap generation failed: '.$e->getMessage());
             $this->error('Sitemap generation failed: '.$e->getMessage());
-
-            return false;
+            return CommandAlias::FAILURE;
         }
     }
 


### PR DESCRIPTION
Introduces two significant improvements to the project.

First, it refines the GitHub Actions workflow by adding a condition to ensure that the workflow only runs if the actor is not Dependabot. This change prevents unnecessary workflow executions triggered by Dependabot, optimizing our CI/CD process and reducing clutter in our workflow logs.

Second, it updates the return type of the `handle` method in the `SitemapGenerateCommand` class from `bool` to `int`. This change aligns the method's return values with the Symfony Console Component's conventions, using constants for success and failure. By returning `Command::SUCCESS` and `Command::FAILURE`, we enhance code clarity and ensure better integration with Symfony's command handling, which improves maintainability and consistency across the codebase.

Overall, these changes improve the efficiency of our CI/CD pipeline and enhance the robustness of our command handling logic.