### PR TITLE
Refactor service provider to register multiple commands using hasCommands method for better scalability.

### DIFF
--- a/src/SitemapServiceProvider.php
+++ b/src/SitemapServiceProvider.php
@@ -23,9 +23,9 @@ class SitemapServiceProvider extends PackageServiceProvider
             ->name('sitemap')
             ->hasConfigFile('fv-sitemap')
             ->hasRoute('web')
-            ->hasCommand(
+            ->hasCommands([
                 SitemapGenerateCommand::class,
-            );
+            ]);
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes

This pull request refactors the `SitemapServiceProvider` to enhance scalability by allowing the registration of multiple commands using the `hasCommands` method.

### Changes
- **File `src/SitemapServiceProvider.php`:**
  - Replaced the `hasCommand` method with `hasCommands`, enabling the registration of multiple commands in an array format.
  - Updated the syntax to use an array for command registration, even though currently only `SitemapGenerateCommand::class` is listed.