### PR TITLE
Tweak sp

### DIFF
--- a/src/SitemapServiceProvider.php
+++ b/src/SitemapServiceProvider.php
@@ -51,5 +51,4 @@ class SitemapServiceProvider extends PackageServiceProvider
             ]);
         }
     }
-
 }

--- a/src/SitemapServiceProvider.php
+++ b/src/SitemapServiceProvider.php
@@ -23,9 +23,9 @@ class SitemapServiceProvider extends PackageServiceProvider
             ->name('sitemap')
             ->hasConfigFile('fv-sitemap')
             ->hasRoute('web')
-            ->hasCommand(
+            ->hasCommands([
                 SitemapGenerateCommand::class,
-            );
+            ]);
     }
 
     /**

--- a/src/SitemapServiceProvider.php
+++ b/src/SitemapServiceProvider.php
@@ -40,4 +40,16 @@ class SitemapServiceProvider extends PackageServiceProvider
         Route::get('/sitemap.xml', SitemapController::class)
             ->name('sitemap');
     }
+
+    public function boot(): void
+    {
+        parent::boot();
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                SitemapGenerateCommand::class,
+            ]);
+        }
+    }
+
 }


### PR DESCRIPTION
Introduces a new `boot` method in the `SitemapServiceProvider` class to register console commands when the application is running in the console. Specifically, it registers the `SitemapGenerateCommand` to be available for execution via the command line. This change enhances the functionality of the service provider by enabling command-line generation of sitemaps.

**Changes:**
1. Added a `boot` method to the `SitemapServiceProvider` class.
2. Within the `boot` method, registered the `SitemapGenerateCommand` to be available when the application is running in the console.