### PR TITLE
Add registration of sitemap generate command to enable console comman…

### DIFF
--- a/src/SitemapServiceProvider.php
+++ b/src/SitemapServiceProvider.php
@@ -41,6 +41,21 @@ class SitemapServiceProvider extends PackageServiceProvider
             ->name('sitemap');
     }
 
+    public function register(): void
+    {
+        parent::register();
+
+        $this->app->singleton('command.sitemap.generate', function () {
+            return new SitemapGenerateCommand();
+        });
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                'command.sitemap.generate',
+            ]);
+        }
+    }
+
     public function boot(): void
     {
         parent::boot();


### PR DESCRIPTION
### Summary of Changes

This pull request registers the `sitemap:generate` command to enable its execution via the console.

### Changes
- **File `src/SitemapServiceProvider.php`:**
  - Added a `register` method to the `SitemapServiceProvider` class.
  - Registered a singleton for the `command.sitemap.generate` command, which returns a new instance of `SitemapGenerateCommand`.
  - Configured the application to recognize and execute the `sitemap:generate` command when running in the console environment.